### PR TITLE
cifsd-tools: delete START & STOP SMBPORT uevents

### DIFF
--- a/cifsd/netlink.c
+++ b/cifsd/netlink.c
@@ -247,24 +247,6 @@ int cifsd_nl_exit(void)
 	return 0;
 }
 
-int cifsd_start_smbport(void)
-{
-	struct cifsd_uevent ev;
-
-	memset(&ev, 0, sizeof(ev));
-	ev.type = CIFSD_UEVENT_START_SMBPORT;
-	return cifsd_common_sendmsg(&ev, NULL, 0);
-}
-
-int cifsd_stop_smbport(void)
-{
-	struct cifsd_uevent ev;
-
-	memset(&ev, 0, sizeof(ev));
-	ev.type = CIFSD_UEVENT_STOP_SMBPORT;
-	return cifsd_common_sendmsg(&ev, NULL, 0);
-}
-
 static void termination_handler(int signum)
 {
 	int err = 0;
@@ -278,7 +260,7 @@ static void termination_handler(int signum)
 	do {
 		connection += failed_connection;
 		failed_connection = 0;
-		err = cifsd_stop_smbport();
+		err = handle_exit_event();
 		if (err < 0) {
 			cifsd_err("cifsd stop smbport failed\n");
 			return;
@@ -313,11 +295,9 @@ int cifsd_netlink_setup(void)
 	initialize();
 	handle_init_event();
 
-	cifsd_start_smbport();
 	cifsd_sighandler();
 	cifsd_nl_loop();
 
-	cifsd_stop_smbport();
 	handle_exit_event();
 	cifsd_nl_exit();
 	return 0;

--- a/cifsd/netlink.h
+++ b/cifsd/netlink.h
@@ -44,8 +44,6 @@ enum cifsd_uevent_e {
 	CIFSD_UEVENT_WRITE_PIPE_RSP,
 	CIFSD_UEVENT_IOCTL_PIPE_RSP,
 	CIFSD_UEVENT_LANMAN_PIPE_RSP,
-	CIFSD_UEVENT_START_SMBPORT,
-	CIFSD_UEVENT_STOP_SMBPORT,
 	CIFSD_UEVENT_EXIT_CONNECTION,
 
 	/* up events: kernel space to userspace */
@@ -122,8 +120,6 @@ struct cifsd_uevent {
 struct list_head cifsd_clients;
 int connection;
 int failed_connection;
-int cifsd_start_smbport(void);
-int cifsd_stop_smbport(void);
 int cifsd_common_sendmsg(struct cifsd_uevent *ev, char *buf,
 		unsigned int buflen);
 int cifsd_netlink_setup(void);


### PR DESCRIPTION
Delete CIFSD_UEVENT_START_SMBPORT and CIFSD_UEVENT_STOP_SMBPORT.
The related functions are merged to CIFSD_UEVENT_INIT_CONNECTION
and CIFSD_UEVENT_EXIT_CONNECTION.

Please check cifsd repo also.
https://github.com/namjaejeon/cifsd/pull/28

Signed-off-by: Taeyang Mok <t.mok@samsung.com>