### PR TITLE
cifsd-tools: delete signal handler registration

### DIFF
--- a/cifsd/netlink.h
+++ b/cifsd/netlink.h
@@ -53,8 +53,7 @@ enum cifsd_uevent_e {
 	CIFSD_KEVENT_IOCTL_PIPE,
 	CIFSD_KEVENT_LANMAN_PIPE,
 	CIFSD_KEVENT_DESTROY_PIPE,
-	CIFSD_KEVENT_SMBPORT_CLOSE_FAIL,
-	CIFSD_KEVENT_SMBPORT_CLOSE_PASS,
+	CFISD_KEVENT_USER_DAEMON_EXIST,
 };
 
 struct cifsd_uevent {
@@ -118,8 +117,6 @@ struct cifsd_uevent {
 
 /* List of connected clients */
 struct list_head cifsd_clients;
-int connection;
-int failed_connection;
 int cifsd_common_sendmsg(struct cifsd_uevent *ev, char *buf,
 		unsigned int buflen);
 int cifsd_netlink_setup(void);

--- a/cifsd/pipecb.c
+++ b/cifsd/pipecb.c
@@ -426,13 +426,9 @@ int request_handler(void *msg)
 		ret = handle_lanman_pipe_event(msg);
 		break;
 
-	case CIFSD_KEVENT_SMBPORT_CLOSE_FAIL:
-		--connection;
-		++failed_connection;
-		break;
-
-	case CIFSD_KEVENT_SMBPORT_CLOSE_PASS:
-		--connection;
+	case CFISD_KEVENT_USER_DAEMON_EXIST:
+		cifsd_err("cifsd already exist!\n");
+		exit(1);
 		break;
 
 	default:


### PR DESCRIPTION
Because smb-port-closing will be handled by kernel side
with new version cisfd, it does not need to register
signal handler for cifsd process.

Please check namjaejeon/cifsd#30 also.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>