### PR TITLE
cifsd-tools: support multiple notify requests

### DIFF
--- a/cifsd/netlink.c
+++ b/cifsd/netlink.c
@@ -180,7 +180,7 @@ static void cifsd_nl_loop(void)
 		FD_SET(nlsk_fd, &readfds);
 
 		ret = select(nlsk_fd + 1, &readfds, NULL, NULL, NULL);
-		if (ret == -1) {
+		if (ret == -1 && errno != EINTR) {
 			perror("select");
 		}
 		else {


### PR DESCRIPTION
Delete codes that makes threads for each notify request.
Change cifsd itself to do add_watch, 
and make one child process to monitor inotify_events from all wd. 
By spliting watch registration and reading inotify events, 
it's possble to handle multiple notify requests from kernel.

cifsd make a child only when there is no one.
Once an inotify event occurs, 
the watch is deleted and the child process exits.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>

Please check cifsd also.