### PR TITLE
cifsd-tools: support multiple sessions

### DIFF
--- a/cifsd/netlink.h
+++ b/cifsd/netlink.h
@@ -165,6 +165,7 @@ struct smb2_inotify_res_info {
 
 /* List of connected clients */
 struct list_head cifsd_clients;
+struct list_head cifsd_notify_clients;
 int cifsd_common_sendmsg(struct cifsd_uevent *ev, char *buf,
 		unsigned int buflen);
 int cifsd_netlink_setup(void);

--- a/include/cifsd.h
+++ b/include/cifsd.h
@@ -110,6 +110,13 @@ struct cifsd_client_info {
         struct list_head pipelist;
 };
 
+struct cifsd_notify_client_info {
+	struct list_head list;
+	__u64 hash;
+	char codepage[CIFSD_CODEPAGE_LEN];
+	int wd;
+};
+
 /* max string size for share and parameters */
 #define SHARE_MAX_NAME_LEN      100
 #define SHARE_MAX_COMMENT_LEN   100


### PR DESCRIPTION
Add a notify-client list to maintain sessions' information.
When an inotify event occurs, cifsd_notifyd will look up
notify client which sent a request and send a netlink response
with the inotify event information.

** Please check cifsd repo also.

Signed-off-by: Taeyang Mok <t.mok@samsung.com>