### PR TITLE
cifsd-tools: pass size_t to base64 API

### DIFF
--- a/cifsdadmin/cifsdadmin.c
+++ b/cifsdadmin/cifsdadmin.c
@@ -114,7 +114,7 @@ static void term_toggle_echo(int on_off)
 	tcsetattr(STDIN_FILENO, TCSAFLUSH, &term);
 }
 
-static char *prompt_password(long *sz)
+static char *prompt_password(size_t *sz)
 {
 	char *pswd1 = malloc(MAX_NT_PWD_LEN + 1);
 	char *pswd2 = malloc(MAX_NT_PWD_LEN + 1);
@@ -176,7 +176,7 @@ again:
 
 static char *get_utf8_password(long *len)
 {
-	long sz;
+	size_t sz;
 	char *pswd1, *pswd2, *pswd1o, *pswd2o;
 	size_t dstsz;
 	iconv_t conv;

--- a/configure.ac
+++ b/configure.ac
@@ -67,9 +67,6 @@ PKG_CHECK_MODULES([LIBNL], [libnl-3.0 >= 3.0 libnl-genl-3.0 >= 3.0], [has_libnl_
 AS_IF([test "$has_libnl_ver" -eq 0], [
 	AC_MSG_ERROR([libnl and libnl-genl are required but were not found])
 ])
-AS_IF([test "$has_libnl_ver" -gt 1], [
-	AC_DEFINE([HAVE_LIBNL20], [1], [Define if you have libnl-2.0 or higher])
-])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/include/cifsdtools.h
+++ b/include/cifsdtools.h
@@ -108,7 +108,7 @@ extern void pr_logger_init(int flags);
 
 void pr_hex_dump(const void *mem, size_t sz);
 
-char *base64_encode(unsigned char *src, unsigned long srclen);
-unsigned char *base64_decode(char const *src, unsigned long *dstlen);
+char *base64_encode(unsigned char *src, size_t srclen);
+unsigned char *base64_decode(char const *src, size_t *dstlen);
 
 #endif /* __CIFSDTOOLS_H__ */

--- a/lib/cifsdtools.c
+++ b/lib/cifsdtools.c
@@ -122,12 +122,12 @@ void pr_hex_dump(const void *mem, size_t sz)
 	}
 }
 
-char *base64_encode(unsigned char *src, unsigned long srclen)
+char *base64_encode(unsigned char *src, size_t srclen)
 {
 	return g_base64_encode(src, srclen);
 }
 
-unsigned char *base64_decode(char const *src, unsigned long *dstlen)
+unsigned char *base64_decode(char const *src, size_t *dstlen)
 {
 	unsigned char *ret = g_base64_decode(src, dstlen);
 	if (ret)

--- a/lib/management/user.c
+++ b/lib/management/user.c
@@ -87,7 +87,7 @@ static struct cifsd_user *new_cifsd_user(char *name, char *pwd)
 {
 	struct cifsd_user *user = malloc(sizeof(struct cifsd_user));
 	struct passwd *passwd;
-	unsigned long pass_sz;
+	size_t pass_sz;
 
 	if (!user)
 		return NULL;
@@ -221,7 +221,7 @@ void for_each_cifsd_user(walk_users cb, gpointer user_data)
 
 int usm_update_user_password(struct cifsd_user *user, char *pswd)
 {
-	unsigned long pass_sz;
+	size_t pass_sz;
 	char *pass_b64 = strdup(pswd);
 	char *pass = base64_decode(pass_b64, &pass_sz);
 


### PR DESCRIPTION
Fix a bunch of 32-bit related gcc warnings.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>