### PR TITLE
cifsd-tools: convert share names to lower-case

### DIFF
--- a/lib/config_parser.c
+++ b/lib/config_parser.c
@@ -70,7 +70,7 @@ static int add_new_group(char *line)
 	while (*end && *end != ']')
 		end = g_utf8_find_next_char(end, NULL);
 
-	name = strndup(begin + 1, end - begin - 1);
+	name = g_ascii_strdown(begin + 1, end - begin - 1);
 	if (!name)
 		goto out_free;
 


### PR DESCRIPTION
Windows does not tolerate upper/lower-case share names and treats
them equally. So should we. kcifsd will send us request with share
names in lower-case.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>
Reported-by: Namjae Jeon <namjae.jeon@protocolfreedom.org>