### PR TITLE
cifsd-tools: rewrite CIFSD_IPC_MSG_PAYLOAD to make static analyzer happy

### DIFF
--- a/include/ipc.h
+++ b/include/ipc.h
@@ -20,8 +20,8 @@ struct cifsd_ipc_msg {
 	unsigned char	____payload[0];
 };
 
-#define CIFSD_IPC_MSG_PAYLOAD(m)	\
-	((void *)(m) + offsetof(struct cifsd_ipc_msg, ____payload))
+#define CIFSD_IPC_MSG_PAYLOAD(m)				\
+	(void *)(((struct cifsd_ipc_msg *)(m))->____payload)
 
 struct cifsd_ipc_msg *ipc_msg_alloc(size_t sz);
 void ipc_msg_free(struct cifsd_ipc_msg *msg);

--- a/lib/management/user.c
+++ b/lib/management/user.c
@@ -303,8 +303,8 @@ int usm_handle_login_request(struct cifsd_login_request *req,
 		global_conf.map_to_guest == CIFSD_CONF_MAP_TO_GUEST_NEVER)
 		return -EINVAL;
 
-	if (guest_login || (!guest_login &&
-		global_conf.map_to_guest == CIFSD_CONF_MAP_TO_GUEST_BAD_USER))
+	if (guest_login ||
+		global_conf.map_to_guest == CIFSD_CONF_MAP_TO_GUEST_BAD_USER)
 		user = usm_lookup_user(global_conf.guest_account);
 
 	if (!user)


### PR DESCRIPTION
The macro is perfetctly fine, but our static analyzer doesn't like
it:
     Arithmetic operations on /void */ is a GNU C extension, which
     defines the /sizeof(void)/ to be 1.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>