### PR TITLE
cifsd-tools: set a proper name for cifsadmin logger

### DIFF
--- a/cifsadmin/cifsadmin.c
+++ b/cifsadmin/cifsadmin.c
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 	char *pwddb = PATH_PWDDB;
 	int c, cmd = 0;
 
-	set_logger_app_name("cifsd_admin");
+	set_logger_app_name("cifsdadmin");
 
 	opterr = 0;
 	while ((c = getopt(argc, argv, "c:i:a:d:u:p:vh")) != EOF)


### PR DESCRIPTION
Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>