### PR TITLE
cifsd-tools: move share config defaults to share header

### DIFF
--- a/include/cifsdtools.h
+++ b/include/cifsdtools.h
@@ -67,9 +67,6 @@ extern struct smbconf_global global_conf;
 #define CIFSD_CONF_DEFAULT_SESS_CAP	1024
 #define CIFSD_CONF_DEFAULT_TPC_PORT	445
 
-#define DEFAULT_CREATE_MASK	0744
-#define DEFAULT_DIRECTORY_MASK	0755
-
 #define PATH_PWDDB	"/etc/cifs/cifsdpwd.db"
 #define PATH_SMBCONF	"/etc/cifs/smb.conf"
 

--- a/include/management/share.h
+++ b/include/management/share.h
@@ -31,6 +31,9 @@ enum share_hosts {
 	CIFSD_SHARE_HOSTS_MAX,
 };
 
+#define CIFSD_SHARE_DEFAULT_CREATE_MASK	0744
+#define CIFSD_SHARE_DEFAULT_DIRECTORY_MASK	0755
+
 struct cifsd_share {
 	char		*name;
 	char		*path;

--- a/lib/management/share.c
+++ b/lib/management/share.c
@@ -412,8 +412,8 @@ static int init_share_from_group(struct cifsd_share *share,
 				 struct smbconf_group *group)
 {
 	share->name = strdup(group->name);
-	share->create_mask = DEFAULT_CREATE_MASK;
-	share->directory_mask = DEFAULT_DIRECTORY_MASK;
+	share->create_mask = CIFSD_SHARE_DEFAULT_CREATE_MASK;
+	share->directory_mask = CIFSD_SHARE_DEFAULT_DIRECTORY_MASK;
 
 	set_share_flag(share, CIFSD_SHARE_FLAG_AVAILABLE);
 	set_share_flag(share, CIFSD_SHARE_FLAG_BROWSEABLE);


### PR DESCRIPTION
Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>