### PR TITLE
cifsd-tools: Replace strerror(errno) with %m

### DIFF
--- a/cifsadmin/cifsadmin.c
+++ b/cifsadmin/cifsadmin.c
@@ -65,7 +65,7 @@ static void notify_cifsd_daemon(int command)
 		return;
 
 	if (read(lock_fd, &manager_pid, sizeof(manager_pid)) == -1) {
-		pr_debug("Unable to read main PID: %s\n", strerror(errno));
+		pr_debug("Unable to read main PID: %m\n");
 		return;
 	}
 
@@ -75,8 +75,7 @@ static void notify_cifsd_daemon(int command)
 
 	pr_debug("Send SIGHUP to pid %d\n", pid);
 	if (kill(pid, SIGHUP))
-		pr_debug("Unable to send siangl to pid %d: %s\n",
-			 pid, strerror(errno));
+		pr_debug("Unable to send siangl to pid %d: %m\n", pid);
 }
 
 static int test_access(char *conf)
@@ -88,7 +87,7 @@ static int test_access(char *conf)
 		return 0;
 	}
 
-	pr_err("%s %s\n", conf, strerror(errno));
+	pr_err("%s %m\n", conf);
 	return -EINVAL;
 }
 

--- a/cifsadmin/user_admin.c
+++ b/cifsadmin/user_admin.c
@@ -66,7 +66,7 @@ again:
 	term_toggle_echo(0);
 	if (fgets(pswd1, MAX_NT_PWD_LEN, stdin) == NULL) {
 		term_toggle_echo(1);
-		pr_err("Fatal error: %s\n", strerror(errno));
+		pr_err("Fatal error: %m\n");
 		free(pswd1);
 		free(pswd2);
 		return NULL;
@@ -75,7 +75,7 @@ again:
 	printf("Retype new password:\n");
 	if (fgets(pswd2, MAX_NT_PWD_LEN, stdin) == NULL) {
 		term_toggle_echo(1);
-		pr_err("Fatal error: %s\n", strerror(errno));
+		pr_err("Fatal error: %m\n");
 		free(pswd1);
 		free(pswd2);
 		return NULL;
@@ -217,7 +217,7 @@ static void write_user(struct cifsd_user *user)
 		if (ret == -1) {
 			if (errno == EINTR)
 				continue;
-			pr_err("%s\n", strerror(errno));
+			pr_err("%m\n");
 			exit(1);
 		}
 
@@ -319,12 +319,12 @@ int command_add_user(char *pwddb, char *account, char *password)
 
 	conf_fd = open(pwddb, O_WRONLY);
 	if (conf_fd == -1) {
-		pr_err("%s %s\n", strerror(errno), pwddb);
+		pr_err("%m %s\n", pwddb);
 		return -EINVAL;
 	}
 
 	if (ftruncate(conf_fd, 0)) {
-		pr_err("%s %s\n", strerror(errno), pwddb);
+		pr_err("%m %s\n", pwddb);
 		close(conf_fd);
 		return -EINVAL;
 	}
@@ -368,12 +368,12 @@ int command_update_user(char *pwddb, char *account, char *password)
 
 	conf_fd = open(pwddb, O_WRONLY);
 	if (conf_fd == -1) {
-		pr_err("%s %s\n", strerror(errno), pwddb);
+		pr_err("%m %s\n", pwddb);
 		return -EINVAL;
 	}
 
 	if (ftruncate(conf_fd, 0)) {
-		pr_err("%s %s\n", strerror(errno), pwddb);
+		pr_err("%m %s\n", pwddb);
 		close(conf_fd);
 		return -EINVAL;
 	}
@@ -404,12 +404,12 @@ int command_del_user(char *pwddb, char *account)
 	conf_fd = open(pwddb, O_WRONLY);
 
 	if (conf_fd == -1) {
-		pr_err("%s %s\n", strerror(errno), pwddb);
+		pr_err("%m %s\n", pwddb);
 		return -EINVAL;
 	}
 
 	if (ftruncate(conf_fd, 0)) {
-		pr_err("%s %s\n", strerror(errno), pwddb);
+		pr_err("%m %s\n", pwddb);
 		close(conf_fd);
 		return -EINVAL;
 	}

--- a/cifsd/cifsd.c
+++ b/cifsd/cifsd.c
@@ -67,7 +67,7 @@ static int create_lock_file()
 
 	sz = snprintf(manager_pid, sizeof(manager_pid), "%d", getpid());
 	if (write(lock_fd, manager_pid, sz) == -1)
-		pr_err("Unable to record main PID: %s\n", strerror(errno));
+		pr_err("Unable to record main PID: %m\n");
 	return 0;
 }
 
@@ -88,9 +88,7 @@ static int wait_group_kill(int signo)
 	int status;
 
 	if (kill(worker_pid, signo) != 0)
-		pr_err("can't execute kill %d: %s\n",
-			worker_pid,
-			strerror(errno));
+		pr_err("can't execute kill %d: %m\n", worker_pid);
 
 	while (1) {
 		pid = waitpid(-1, &status, 0);
@@ -117,8 +115,8 @@ static int setup_signal_handler(int signo, sighandler_t handler)
 
 	status = sigaction(signo, &act, NULL);
 	if (status != 0)
-		pr_err("Unable to register %s signal handler: %s",
-				strsignal(signo), strerror(errno));
+		pr_err("Unable to register %s signal handler: %m",
+				strsignal(signo));
 	return status;
 }
 
@@ -211,8 +209,8 @@ static void manager_sig_handler(int signo)
 
 		cifsd_health_status |= CIFSD_SHOULD_RELOAD_CONFIG;
 		if (kill(worker_pid, signo))
-			pr_err("Unable to send SIGHUP to %d: %s\n",
-				worker_pid, strerror(errno));
+			pr_err("Unable to send SIGHUP to %d: %m\n",
+				worker_pid);
 		return;
 	}
 
@@ -314,7 +312,7 @@ static pid_t start_worker_process(worker_fn fn)
 
 	__pid = fork();
 	if (__pid < 0) {
-		pr_err("Can't fork child process: `%s'\n", strerror(errno));
+		pr_err("Can't fork child process: `%m'\n");
 		return -EINVAL;
 	}
 	if (__pid == 0) {
@@ -338,7 +336,7 @@ static int manager_process_init(void)
 	}
 
 	if (create_lock_file()) {
-		pr_err("Failed to create lock file: %s\n", strerror(errno));
+		pr_err("Failed to create lock file: %m\n");
 		goto out;
 	}
 
@@ -360,8 +358,7 @@ static int manager_process_init(void)
 		pr_err("WARNING: child process exited abnormally: %d\n",
 				child);
 		if (child == -1) {
-			pr_err("waitpid() returned error code: %s\n",
-				strerror(errno));
+			pr_err("waitpid() returned error code: %m\n");
 			goto out;
 		}
 

--- a/cifsd/ipc.c
+++ b/cifsd/ipc.c
@@ -155,7 +155,7 @@ static int ipc_cifsd_shutting_down(void)
 int ipc_process_event(void)
 {
 	if (nl_recvmsgs_default(sk) < 0) {
-		pr_err("Recv() error %s\n", strerror(errno));
+		pr_err("Recv() error %m\n");
 		return -EINVAL;
 	}
 	return 0;


### PR DESCRIPTION
%m is a GNU extension that is also supported by the major C libraries
(glibc, musl, uclibc-ng, BIONIC). It saves size by avoiding a function
call.

Signed-off-by: Rosen Penev <rosenp@gmail.com>