### PR TITLE
Revert "cifsd-tools: password hash size should be 16"

### DIFF
--- a/lib/management/user.c
+++ b/lib/management/user.c
@@ -292,7 +292,7 @@ static void __handle_login_request(struct cifsd_login_response *resp,
 	hash_sz = usm_copy_user_passhash(user,
 					 resp->hash,
 					 sizeof(resp->hash));
-	if (hash_sz != CIFSD_REQ_MAX_HASH_SZ - 2) {
+	if (hash_sz < 0) {
 		resp->status = CIFSD_USER_FLAG_INVALID;
 	} else {
 		resp->hash_sz = (unsigned short)hash_sz;


### PR DESCRIPTION
This reverts commit dac42869be0c013c75c279a7063583665f46431c.