### PR TITLE
cifsd-tools: change strcpy() to strncpy().

### DIFF
--- a/cifsd/ipc.c
+++ b/cifsd/ipc.c
@@ -152,7 +152,9 @@ static int ipc_cifsd_starting_up(void)
 		char *config_payload;
 
 		config_payload = CIFSD_STARTUP_CONFIG_INTERFACES(ev);
-		strcpy(config_payload, global_conf.interfaces);
+		strncpy(config_payload,
+				global_conf.interfaces,
+				sizeof(config_payload) - 1);
 	}
 
 	ret = ipc_msg_send(msg);


### PR DESCRIPTION
change strcpy() to strncpy()
because Buffer overflow may occur if the
data is larger than the buffer size.

Signed-off-by: Gibeom Kim <gibeomii.kim@samsung.com>