### PR TITLE
cifsd-tools: remove unneeded libnl for cifsuseradd and cifsshareadd

### DIFF
--- a/cifsshareadd/Makefile.am
+++ b/cifsshareadd/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
-LIBS = $(GLIB_LIBS) $(LIBNL_LIBS)
+LIBS = $(GLIB_LIBS)
 cifsshareadd_LDADD = $(top_builddir)/lib/libcifsdtools.la
 
 sbin_PROGRAMS = cifsshareadd

--- a/cifsuseradd/Makefile.am
+++ b/cifsuseradd/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
-LIBS = $(GLIB_LIBS) $(LIBNL_LIBS)
+LIBS = $(GLIB_LIBS)
 cifsuseradd_LDADD = $(top_builddir)/lib/libcifsdtools.la
 
 sbin_PROGRAMS = cifsuseradd

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.68])
 
 m4_define([cifsd_tools_major_ver], [2])
 m4_define([cifsd_tools_minor_ver], [0])
-m4_define([cifsd_tools_micro_ver], [3])
+m4_define([cifsd_tools_micro_ver], [4])
 
 m4_define([cifsd_tools_version],
 	[cifsd_tools_major_ver.cifsd_tools_minor_ver.cifsd_tools_micro_ver])


### PR DESCRIPTION
Signed-off-by: Andy Walsh <andy.walsh44@gmail.com>
Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>